### PR TITLE
Updated RF_Module.dcm with MDBT42Q file

### DIFF
--- a/RF_Module.dcm
+++ b/RF_Module.dcm
@@ -241,3 +241,13 @@ F http://www.wireless-solutions.de/images/stories/downloads/Radio%20Modules/iM88
 $ENDCMP
 #
 #End Doc Library
+
+EESchema-DOCLIB  Version 2.0
+#
+$CMP MDBT42Q
+D MDBT42Q bluetooth low energy(BLE)
+K  GPIO SPI UART I2C I2S PWM
+F https://statics3.seeedstudio.com/assets/file/bazaar/product/MDBT42Q-Version_B.pdf
+$ENDCMP
+#
+#End Doc Library


### PR DESCRIPTION
I have added the dcm extension file into this.

Raytac’s MDBT42Q is a BT 4.0, BT 4.1 and BT 4.2 stack (Bluetooth low energy or BLE) module designed based on Nordic nRF52832 SoC solution, which incorporates: GPIO, SPI, UART, I2C, I2S, PWM and ADC interfaces for connecting peripherals and sensors.

Thanks for creating a pull request to contribute to the KiCad libraries! To speed up integration of your PR, please check the following items:

- [ ] Provide a URL to a datasheet for the symbol(s) you are contributing
- [ ] An example screenshot image is very helpful
- [ ] Ensure that the associated footprints match the [official footprint library](https://github.com/kicad/kicad-footprints)
  - A new fitting footprint must be submitted if the library does not yet contain one.
- [ ] If there are matching footprint PRs, provide link(s) as appropriate
- [ ] Check the output of the Travis automated check scripts - fix any errors as required
- [ ] Give a reason behind any intentional library convention rule violation.

1.URL: https://statics3.seeedstudio.com/assets/file/bazaar/product/MDBT42Q-Version_B.pdf

2.Screenshot of the image
![screenshot_mdbt42q](https://user-images.githubusercontent.com/55408935/81501518-702f9c80-92f6-11ea-8b67-f9af4d4e915c.JPG)

3.I have pulled a request as well for the footprint.
KiCad/kicad-footprints#1891



